### PR TITLE
Fix for Issue #54.

### DIFF
--- a/DayZ/configs/cfgServer.lua
+++ b/DayZ/configs/cfgServer.lua
@@ -33,13 +33,22 @@ gameplayVariables["realtime"] = false -- Enables/Disables real time use. When di
 gameplayVariables["customtime"] = 10000 -- How long should an ingame minute be (in ms)? Example: 10000ms (10s) realtime = 1 minute gametime - DEFAULT: 10000
 gameplayVariables["pingkick"] = true -- Should the ping kicker be enabled? - DEFAULT: true
 gameplayVariables["maxzombiesglobal"] = 600 -- Not in use
+
+-- BACKPACK SETTINGS | Use common sense when changing the weapon slots! Nobody likes backpacks with 3 item slots and 500 weapon slots.
 gameplayVariables["assaultpack_slots"] = 12 -- Slots for Assault Pack (ACU) - DEFAULT: 12
+gameplayVariables["assaultpack_gunslots"] = 1 -- Weapon slots for Assault Pack (ACU) - DEFAULT: 1
 gameplayVariables["czechvest_slots"] = 13 -- Slots for Czech Vest Pouch - DEFAULT: 13
+gameplayVariables["czechvest_gunslots"] = 1 -- Weapon slots for Czech Vest Pouch - DEFAULT: 1
 gameplayVariables["alice_slots"] = 16 -- Slots for ALICE Pack - DEFAULT: 16
+gameplayVariables["alice_gunslots"] = 1 -- Weapon slots for ALICE Pack - DEFAULT: 1
 gameplayVariables["survival_slots"] = 17 -- Slots for Survival ACU - DEFAULT: 17
+gameplayVariables["survival_gunslots"] = 1 -- Weapon slots for Survival ACU - DEFAULT: 1
 gameplayVariables["britishassault_slots"] = 18 -- Slots for British Assault Pack - DEFAULT: 18
+gameplayVariables["britishassault_gunslots"] = 1 -- Weapon slots for British Assault Pack - DEFAULT: 1
 gameplayVariables["coyote_slots"] = 24 -- Slots for Backpack (Coyote) - DEFAULT: 24
+gameplayVariables["coyote_gunslots"] = 2 -- Weapon slots for Backpack (Coyote) - DEFAULT: 2
 gameplayVariables["czech_slots"] = 30 -- Slots for Czech Backpack - DEFAULT: 30
+gameplayVariables["czech_gunslots"] = 6 -- Weapon slots for Czech Backpack - DEFAULT: 6
 	
 -- SERVER BACKUP
 gameplayVariables["backupenabled"] = true -- Whether or not backup should be enabled. Backup = saves all tents, accounts & vehicles. - DEFAULT: true - Set to false to disable backup.

--- a/DayZ/handlers/players/server/actions_player.lua
+++ b/DayZ/handlers/players/server/actions_player.lua
@@ -143,25 +143,25 @@ function onPlayerEquipBackpack(itemName)
 	local backpack_weapons = 0
 	if itemName == "Assault Pack (ACU)" then
 		backpack_item = gameplayVariables["assaultpack_slots"]
-		backpack_weapons = 1
+		backpack_weapons = gameplayVariables["assaultpack_gunslots"]
 	elseif itemName == "Czech Vest Pouch" then
 		backpack_item = gameplayVariables["czechvest_slots"]
-		backpack_weapons = 1
+		backpack_weapons = gameplayVariables["czechvest_gunslots"]
 	elseif itemName == "ALICE Pack" then
 		backpack_item = gameplayVariables["alice_slots"]
-		backpack_weapons = 1
+		backpack_weapons = gameplayVariables["alice_gunslots"]
 	elseif itemName == "Survival ACU" then
 		backpack_item = gameplayVariables["survival_slots"]
-		backpack_weapons = 1
+		backpack_weapons = gameplayVariables["survival_gunslots"]
 	elseif itemName == "British Assault Pack" then
 		backpack_item = gameplayVariables["britishassault_slots"]
-		backpack_weapons = 1
+		backpack_weapons = gameplayVariables["britishassault_gunslots"]
 	elseif itemName == "Backpack (Coyote)" then
 		backpack_item = gameplayVariables["coyote_slots"]
-		backpack_weapons = 2
+		backpack_weapons = gameplayVariables["coyote_gunslots"]
 	elseif itemName == "Czech Backpack" then
 		backpack_item = gameplayVariables["czech_slots"]
-		backpack_weapons = 6
+		backpack_weapons = gameplayVariables["czech_gunslots"]
 	end
 	setElementData(source,itemName,getElementData(source,itemName)-1)
 	setElementData(source,"Backpack_Slots",backpack_item)

--- a/DayZ/handlers/players/server/actions_player.lua
+++ b/DayZ/handlers/players/server/actions_player.lua
@@ -142,25 +142,25 @@ function onPlayerEquipBackpack(itemName)
 	local backpack_item = 0
 	local backpack_weapons = 0
 	if itemName == "Assault Pack (ACU)" then
-		backpack_item = 12
+		backpack_item = gameplayVariables["assaultpack_slots"]
 		backpack_weapons = 1
 	elseif itemName == "Czech Vest Pouch" then
-		backpack_item = 13
+		backpack_item = gameplayVariables["czechvest_slots"]
 		backpack_weapons = 1
 	elseif itemName == "ALICE Pack" then
-		backpack_item = 16
+		backpack_item = gameplayVariables["alice_slots"]
 		backpack_weapons = 1
 	elseif itemName == "Survival ACU" then
-		backpack_item = 17
+		backpack_item = gameplayVariables["survival_slots"]
 		backpack_weapons = 1
 	elseif itemName == "British Assault Pack" then
-		backpack_item = 18
+		backpack_item = gameplayVariables["britishassault_slots"]
 		backpack_weapons = 1
 	elseif itemName == "Backpack (Coyote)" then
-		backpack_item = 24
+		backpack_item = gameplayVariables["coyote_slots"]
 		backpack_weapons = 2
 	elseif itemName == "Czech Backpack" then
-		backpack_item = 30
+		backpack_item = gameplayVariables["czech_slots"]
 		backpack_weapons = 6
 	end
 	setElementData(source,itemName,getElementData(source,itemName)-1)


### PR DESCRIPTION
Did some digging, and found file /handlers/players/server/actions_player.lua which still had numeric definitions for backpack sizes. Replaced sizes with 'gameplayVariables["*_slots"]'.
## EDIT

I also added 'gameplayVariables["*_gunslots"]' for weapon slots. Now you should be able to edit them all directly from cfgServer.lua...
