### PR TITLE
Repair eat weapons

### DIFF
--- a/DayZ/gui/gear/ui_gear.lua
+++ b/DayZ/gui/gear/ui_gear.lua
@@ -881,7 +881,9 @@ function itemLabelClicked(button)
 			if info then
 				--playerUseItem(name, info)
 				--setTimer(placeItemsInInventory, 200, 2)
+				if not isPlayerInLoot() then
 				showRightClickMenu(name,info,description)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Added "if not isPlayerInLoot ()" before displaying "Right Click Menu", repairing the bug with eat weapons.